### PR TITLE
fix: network resilience patch crash if get API.DeviceID fail

### DIFF
--- a/CHANGELOG-sdk-patch.md
+++ b/CHANGELOG-sdk-patch.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- In some case `NetworkResilience` patch will throw `NullReferenceException` during initialize HttpClient.
+- In some case `NetworkResilience` patch will throw `NullReferenceException` during initialize HttpClient. [`#50`](https://github.com/project-vrcz/yet-another-sdk-patch/pull/50) [`#51`](https://github.com/project-vrcz/yet-another-sdk-patch/pull/51)
 
 ## [0.3.0] - 2026-03-12
 

--- a/src/Packages/xyz.misakal.vpm.yet-another-sdk-patch/Editor/Patches/NetworkResilience/VrcApiHttpClientFactory.cs
+++ b/src/Packages/xyz.misakal.vpm.yet-another-sdk-patch/Editor/Patches/NetworkResilience/VrcApiHttpClientFactory.cs
@@ -6,12 +6,15 @@ using System.Threading;
 using UnityEngine;
 using VRC;
 using VRC.Core;
+using YesPatchFrameworkForVRChatSdk.PatchApi.Logging;
 using YetAnotherPatchForVRChatSdk.Extensions;
 
 namespace YetAnotherPatchForVRChatSdk.Patches.NetworkResilience;
 
 internal sealed class VrcApiHttpClientFactory
 {
+    private const string LoggerSource = nameof(NetworkResiliencePatch) + "." + nameof(VrcApiHttpClientFactory);
+
     public delegate void SetupCookieContainerGetCookiesDelegate(CookieContainer cookieContainer);
 
     private readonly SetupCookieContainerGetCookiesDelegate _setupCookieContainer;
@@ -60,7 +63,15 @@ internal sealed class VrcApiHttpClientFactory
         var client = new HttpClient(handler);
         client.Timeout = Timeout.InfiniteTimeSpan;
 
-        client.DefaultRequestHeaders.Add("X-MacAddress", API.DeviceID);
+        try
+        {
+            client.DefaultRequestHeaders.Add("X-MacAddress", API.DeviceID);
+        }
+        catch (Exception ex)
+        {
+            YesLogger.LogDebug(ex, LoggerSource, "Failed to add X-MacAddress header", null);
+        }
+
         foreach (var header in _defaultRequestHeaders)
         {
             client.DefaultRequestHeaders.Add(header.Key, header.Value);


### PR DESCRIPTION
workaround for #47 